### PR TITLE
Replace configuration with new style

### DIFF
--- a/Classes/Utility/Concat.php
+++ b/Classes/Utility/Concat.php
@@ -26,8 +26,9 @@ class Concat extends \TYPO3\CMS\Core\Page\PageRenderer {
     public function initS3() {
 
         /* Retrieve extension configuration */
-        $this->s3ExtConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['tm_s3assets']);
-        $this->s3ExtConfiguration = $this->s3ExtConfiguration['s3.'];
+//        $this->s3ExtConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['tm_s3assets']);
+//        $this->s3ExtConfiguration = $this->s3ExtConfiguration['s3.'];
+        $this->s3ExtConfiguration = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['tm_s3assets']);
 
 
         $this->S3bucket = $this->s3ExtConfiguration['bucket'];

--- a/Classes/Utility/Concat.php
+++ b/Classes/Utility/Concat.php
@@ -26,10 +26,11 @@ class Concat extends \TYPO3\CMS\Core\Page\PageRenderer {
     public function initS3() {
 
         /* Retrieve extension configuration */
-//        $this->s3ExtConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['tm_s3assets']);
-//        $this->s3ExtConfiguration = $this->s3ExtConfiguration['s3.'];
-        $this->s3ExtConfiguration = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['tm_s3assets']);
-
+        $this->s3ExtConfiguration = $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['tm_s3assets']['s3'];
+        if (!$this->s3ExtConfiguration) {
+                $this->s3ExtConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['tm_s3assets']);
+                $this->s3ExtConfiguration = $this->s3ExtConfiguration['s3.'];
+        }
 
         $this->S3bucket = $this->s3ExtConfiguration['bucket'];
         $this->S3protocol = $this->s3ExtConfiguration['protocol'];


### PR DESCRIPTION
I think we should add a condition so both styles of configuration may be used.

Example of new style:

```
        'tm_s3assets' => [
            'apikey' => getenv('TYPO3_TM_S3ASSETS_ACCESS_KEY_ID'),
            'apisecret' => getenv('TYPO3_TM_S3ASSETS_SECRET_KEY'),
            'region' => getenv('TYPO3_TM_S3ASSETS_REGION'),
            'version' => 'latest',
            'bucket' => getenv('TYPO3_TM_S3ASSETS_BUCKET_NAME'),
            'cdn' => getenv('TYPO3_TM_S3ASSETS_DOMAIN'),
            'protocol' => 'https',
            'baseDir' => 'assets/',
        ],
```